### PR TITLE
Servindo media

### DIFF
--- a/blog/settings.py
+++ b/blog/settings.py
@@ -106,3 +106,7 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+
+# onde ficam salvos arquivos de upload
+MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+MEDIA_URL = '/media/'

--- a/blog/urls.py
+++ b/blog/urls.py
@@ -13,12 +13,27 @@ Including another URLconf
     1. Add an import:  from blog import urls as blog_urls
     2. Add a URL to urlpatterns:  url(r'^blog/', include(blog_urls))
 """
-from django.conf.urls import include, url
+import os
+from django.conf import settings
+from django.conf.urls import include, url, patterns
+from django.conf.urls.static import static
+from django.views.generic.base import RedirectView
 from django.contrib import admin
-from wagtail.wagtailimages import urls as wagtailimages_urls
+# from wagtail.wagtailimages import urls as wagtailimages_urls
 
 urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
-    url(r'^images/', include(wagtailimages_urls)),
+    # url(r'^images/', include(wagtailimages_urls)),
     url(r'', include('puput.urls')),
 ]
+
+
+if settings.DEBUG:
+    from django.contrib.staticfiles.urls import staticfiles_urlpatterns
+
+    urlpatterns += staticfiles_urlpatterns()  # tell gunicorn where static files are in dev mode
+    urlpatterns += static(settings.MEDIA_URL + 'images/', document_root=os.path.join(settings.MEDIA_ROOT, 'images'))
+    urlpatterns += patterns(
+        '',
+        (r'^favicon\.ico$', RedirectView.as_view(url=settings.STATIC_URL + 'blog/images/favicon.ico'))
+    )


### PR DESCRIPTION
Tinha esquecido que precisava por as settings de MEDIA_ROOT e MEDIA_URL.
Antigamente quando rodava o `startproject` do django, ele criava um settings.py que tinha uns valores padrões pra esses caras, mas hj em dia ele não poem eles no settings.py criado, dai o valor fica vazio pra eles.

além de setar esses caras, precisa por no `urls.py` para que o django sirva, em tempo de desenvolvimento, esses arquivos de media. Por padrão o django não faz isso, e não se deve fazer isso em prod tmb, pois não vale a pena usar o django para isso (ele não faz isso de forma otimizada nem nada).
Em produção pode ser usado, por exemplo, o nginx.
Assim, vc diz que na url `/images/` o nginx vai carregar o arquivo que for pedido (ex: `/images/minha_logo.png`). Assim não precisa passar pelo Django para carregar algo simples como uma imagem.

Mas como em desenvolvimento não se tem o nginx rodando, vc faz esse "workaround" pra poder forçar o django a servir os arquivos pedidos =)
